### PR TITLE
Project card divider height updated to match figma design

### DIFF
--- a/.env copy.template
+++ b/.env copy.template
@@ -1,1 +1,0 @@
-NEXT_PUBLIC_API_BASE_URL=https://prolog-api.profy.dev

--- a/features/projects/components/project-card/project-card.module.scss
+++ b/features/projects/components/project-card/project-card.module.scss
@@ -19,7 +19,7 @@
 
 .bottomContainer {
   padding: space.$s4 space.$s6;
-  border-top: 3px solid color.$gray-200;
+  border-top: 1px solid color.$gray-200;
   display: flex;
   justify-content: flex-end;
 }


### PR DESCRIPTION
Fixed the bottom container styling of the project card component to match that of the figma design.

Original:

![Original](https://github.com/profydev/prolog-app-Hudson-TD/assets/107374040/21acc228-fe0e-4ef4-854c-37d2cdb7e7bd)

Fixed:

![Fixed](https://github.com/profydev/prolog-app-Hudson-TD/assets/107374040/4ff46168-dabb-4530-b32b-bd4fcb1936b6)
