### PR TITLE
Fixed pagination text color on issue list component

### DIFF
--- a/features/issues/components/issue-list/issue-list.module.scss
+++ b/features/issues/components/issue-list/issue-list.module.scss
@@ -51,7 +51,7 @@
 }
 
 .pageInfo {
-  color: color.$gray-300;
+  color: color.$gray-700;
   font: font.$text-sm-regular;
 }
 


### PR DESCRIPTION
Updated pagination text color on the issue list component from **gray-300** to **gray-700**, matching the figma design file.


Original:

![Original_Issues_List_Pagination](https://github.com/profydev/prolog-app-Hudson-TD/assets/107374040/be8b638e-afd8-45de-9ace-4f6192540793)

Fixed:

![Fixed_Issues_List_Pagination](https://github.com/profydev/prolog-app-Hudson-TD/assets/107374040/27249a13-e59a-430b-b9d2-bb6e51ffa11e)

