### PR TITLE
Fix issue list number of events and users

### DIFF
--- a/api/issues.types.ts
+++ b/api/issues.types.ts
@@ -12,4 +12,5 @@ export type Issue = {
   stack: string;
   level: IssueLevel;
   numEvents: number;
+  numUsers: number;
 };

--- a/cypress/e2e/issue-list.cy.ts
+++ b/cypress/e2e/issue-list.cy.ts
@@ -82,5 +82,31 @@ describe("Issue List", () => {
       cy.wait(1500);
       cy.contains("Page 2 of 3");
     });
+
+    it.only("reflects correct values in Users column", () => {
+      // Verify page 1 Users column values
+      cy.contains("Page 1 of 3");
+      cy.get("main")
+        .find("tbody")
+        .find("tr")
+        .each(($el, index) => {
+          const issue = mockIssues1.items[index];
+          cy.wrap($el).contains(issue.numUsers);
+        });
+
+      // Navigate to page 2
+      cy.get("@next-button").click();
+      // Buffer for page loading
+      cy.wait(3000);
+      cy.contains("Page 2 of 3");
+      // Verify page 2 Users column values
+      cy.get("main")
+        .find("tbody")
+        .find("tr")
+        .each(($el, index) => {
+          const issue = mockIssues2.items[index];
+          cy.wrap($el).contains(issue.numUsers);
+        });
+    });
   });
 });

--- a/features/issues/components/issue-list/issue-row.tsx
+++ b/features/issues/components/issue-list/issue-row.tsx
@@ -17,7 +17,7 @@ const levelColors = {
 };
 
 export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
-  const { name, message, stack, level, numEvents } = issue;
+  const { name, message, stack, level, numEvents, numUsers } = issue;
   const firstLineOfStackTrace = stack.split("\n")[1];
 
   return (
@@ -43,7 +43,7 @@ export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
         </Badge>
       </td>
       <td className={styles.cell}>{numEvents}</td>
-      <td className={styles.cell}>{numEvents}</td>
+      <td className={styles.cell}>{numUsers}</td>
     </tr>
   );
 }


### PR DESCRIPTION
1.) Updated 'Issue' typing to include numUsers value from our API.
2.) Replaced numEvents with numUsers in the appropriate td element.
2.) Implemented Cypress test to verify UI is showing correct Users count against mocked data.

Original:

![issues_user_count_original](https://github.com/profydev/prolog-app-Hudson-TD/assets/107374040/5a1096aa-bbcd-4155-a4c1-9e1b6e5d682c)


Fixed:

![issues_user_count_fixed](https://github.com/profydev/prolog-app-Hudson-TD/assets/107374040/ad6cf1e1-3ba5-46c4-8589-2e53750ef2e7)
