### PR TITLE
Projects error screen

### DIFF
--- a/cypress/e2e/project-list.cy.ts
+++ b/cypress/e2e/project-list.cy.ts
@@ -42,3 +42,37 @@ describe("Project List", () => {
     });
   });
 });
+
+describe.only("Project List Fetching Error", () => {
+  beforeEach(() => {
+    // Intercept API call to trigger error alter component render
+    cy.intercept("GET", "https://prolog-api.profy.dev/project", {
+      statusCode: 500,
+      body: "Expected error message text",
+    }).as("getError");
+
+    // Open `Projects` page
+    cy.visit("http://localhost:3000/dashboard");
+  });
+
+  context("desktop resolution", () => {
+    beforeEach(() => {
+      cy.viewport(1025, 900);
+    });
+
+    it("Correctly renders error alert component", () => {
+      // Buffer to allow component render
+      cy.wait(9000);
+      cy.get("main").contains("Request failed with status code 500");
+    });
+
+    it("Handles refetch when Try Again button is clicked", () => {
+      // Buffer to allow component render
+      cy.wait(9000);
+      cy.get("main").contains("button", "Try again").click();
+      // Second attempt buffer
+      cy.wait(9000);
+      cy.get("main").contains("Request failed with status code 500");
+    });
+  });
+});

--- a/features/projects/components/project-list/project-list.module.scss
+++ b/features/projects/components/project-list/project-list.module.scss
@@ -1,7 +1,5 @@
 @use "@styles/breakpoint";
 @use "@styles/space";
-@use "@styles/color";
-@use "@styles/font";
 
 .list {
   display: grid;

--- a/features/projects/components/project-list/project-list.module.scss
+++ b/features/projects/components/project-list/project-list.module.scss
@@ -1,5 +1,7 @@
 @use "@styles/breakpoint";
 @use "@styles/space";
+@use "@styles/color";
+@use "@styles/font";
 
 .list {
   display: grid;

--- a/features/projects/components/project-list/project-list.tsx
+++ b/features/projects/components/project-list/project-list.tsx
@@ -1,7 +1,7 @@
 import { ProjectCard } from "../project-card";
 import { useGetProjects } from "../../api/use-get-projects";
+import { ErrorAlert } from "../../../ui/error/error-alert";
 import styles from "./project-list.module.scss";
-
 export function ProjectList() {
   const { data, isLoading, isError, error } = useGetProjects();
 
@@ -11,7 +11,7 @@ export function ProjectList() {
 
   if (isError) {
     console.error(error);
-    return <div>Error: {error.message}</div>;
+    return <ErrorAlert errorData={error} />;
   }
 
   return (

--- a/features/projects/components/project-list/project-list.tsx
+++ b/features/projects/components/project-list/project-list.tsx
@@ -3,7 +3,7 @@ import { useGetProjects } from "../../api/use-get-projects";
 import { ErrorAlert } from "../../../ui/error/error-alert";
 import styles from "./project-list.module.scss";
 export function ProjectList() {
-  const { data, isLoading, isError, error } = useGetProjects();
+  const { data, isLoading, isError, error, refetch } = useGetProjects();
 
   if (isLoading) {
     return <div>Loading</div>;
@@ -11,7 +11,7 @@ export function ProjectList() {
 
   if (isError) {
     console.error(error);
-    return <ErrorAlert errorData={error} />;
+    return <ErrorAlert errorData={error} handleRefetch={() => refetch()} />;
   }
 
   return (

--- a/features/ui/error/error-alert.module.scss
+++ b/features/ui/error/error-alert.module.scss
@@ -1,0 +1,36 @@
+@use "@styles/color";
+@use "@styles/font";
+
+.errorContainer {
+  background-color: color.$error-25;
+  border: 1px solid color.$error-300;
+  border-radius: 8px;
+  width: 100%;
+  margin-top: 32px;
+}
+
+.errorContent {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  height: 20px;
+  padding: 16px;
+}
+
+.errorText {
+  color: color.$error-700;
+  font: font.$text-sm-semibold;
+}
+
+.errorButtonContainer {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-left: auto;
+}
+
+.errorButton {
+  padding: 0;
+  border: none;
+  background-color: color.$error-25;
+}

--- a/features/ui/error/error-alert.module.scss
+++ b/features/ui/error/error-alert.module.scss
@@ -5,7 +5,7 @@
   background-color: color.$error-25;
   border: 1px solid color.$error-300;
   border-radius: 8px;
-  width: 100%;
+  max-width: 100%;
   margin-top: 32px;
 }
 
@@ -13,13 +13,13 @@
   display: flex;
   gap: 12px;
   align-items: center;
-  height: 20px;
-  padding: 16px;
+  margin: 0 12px;
 }
 
-.errorText {
-  color: color.$error-700;
-  font: font.$text-sm-semibold;
+.errorMsgContainer {
+  flex-grow: 2;
+  line-height: 20px;
+  width: 100%;
 }
 
 .errorButtonContainer {
@@ -29,8 +29,17 @@
   margin-left: auto;
 }
 
+.errorText {
+  color: color.$error-700;
+  font: font.$text-sm-medium;
+}
+
 .errorButton {
-  padding: 0;
+  white-space: nowrap;
   border: none;
   background-color: color.$error-25;
+}
+
+.errorButtonContainer:hover {
+  color: color.$gray-900;
 }

--- a/features/ui/error/error-alert.tsx
+++ b/features/ui/error/error-alert.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import classNames from "classnames";
+import styles from "./error-alert.module.scss";
+
+type ErrorAlertProps = {
+  errorData: Error;
+};
+
+export function ErrorAlert({ errorData }: ErrorAlertProps) {
+  return (
+    <>
+      <div className={styles.errorContainer}>
+        <div className={styles.errorContent}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={`/icons/alert-circle.svg`} alt="alert-circle" />
+          <p className={styles.errorText}>{errorData.message}</p>
+          <div className={styles.errorButtonContainer}>
+            <button
+              className={classNames(styles.errorButton, styles.errorText)}
+            >
+              Try again
+            </button>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={`/icons/arrow-right.svg`} alt="arrow-right" />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/features/ui/error/error-alert.tsx
+++ b/features/ui/error/error-alert.tsx
@@ -4,18 +4,22 @@ import styles from "./error-alert.module.scss";
 
 type ErrorAlertProps = {
   errorData: Error;
+  handleRefetch: () => void;
 };
 
-export function ErrorAlert({ errorData }: ErrorAlertProps) {
+export function ErrorAlert({ errorData, handleRefetch }: ErrorAlertProps) {
   return (
     <>
       <div className={styles.errorContainer}>
         <div className={styles.errorContent}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img src={`/icons/alert-circle.svg`} alt="alert-circle" />
-          <p className={styles.errorText}>{errorData.message}</p>
+          <p className={classNames(styles.errorMsgContainer, styles.errorText)}>
+            {errorData.message}
+          </p>
           <div className={styles.errorButtonContainer}>
             <button
+              onClick={handleRefetch}
               className={classNames(styles.errorButton, styles.errorText)}
             >
               Try again

--- a/features/ui/error/index.tsx
+++ b/features/ui/error/index.tsx
@@ -1,0 +1,1 @@
+export { ErrorAlert } from "./error-alert";

--- a/features/ui/index.ts
+++ b/features/ui/index.ts
@@ -1,2 +1,3 @@
 export * from "./badge";
 export * from "./button";
+export * from "./error";

--- a/public/icons/alert-circle.svg
+++ b/public/icons/alert-circle.svg
@@ -1,0 +1,10 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_644_24409)">
+<path d="M10 6.66675V10.0001M10 13.3334H10.0084M18.3334 10.0001C18.3334 14.6025 14.6024 18.3334 10 18.3334C5.39765 18.3334 1.66669 14.6025 1.66669 10.0001C1.66669 5.39771 5.39765 1.66675 10 1.66675C14.6024 1.66675 18.3334 5.39771 18.3334 10.0001Z" stroke="#D92D20" stroke-width="1.66667" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_644_24409">
+<rect width="20" height="20" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/public/icons/arrow-right.svg
+++ b/public/icons/arrow-right.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4.16669 10.0001H15.8334M15.8334 10.0001L10 4.16675M15.8334 10.0001L10 15.8334" stroke="#B42318" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
1.) Created a new reusable component "error-alert" matching the Figma design specifications. This component ingests Error object passed via props and reflects text content.

2.) Implemented Cypress testing for conditional rendering of this component, the expected content, and it's refetch onClick functionality.


Desktop Breakpoint:

![error_alert_desktop](https://github.com/profydev/prolog-app-Hudson-TD/assets/107374040/3984d13f-e778-41cd-8721-3b5b4694a7ab)

Mobile Breakpoint: 

![error_alert_mobile](https://github.com/profydev/prolog-app-Hudson-TD/assets/107374040/c78c85c9-a2b6-4ffa-9e92-b19c5e0c3bfd)

