### PR TITLE
Landing page header

### DIFF
--- a/config/routes.tsx
+++ b/config/routes.tsx
@@ -5,4 +5,7 @@ export const Routes = {
   alerts: "/dashboard/alerts",
   users: "/dashboard/users",
   settings: "/dashboard/settings",
+  products: "/products",
+  documentation: "/documentation",
+  pricing: "/pricing",
 };

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,13 +1,88 @@
+import { useState, useEffect } from "react";
 import { Routes } from "@config/routes";
+import { Button } from "../features/ui/button/button";
+import Link from "next/link";
 import styles from "./index.module.scss";
+import classNames from "classnames";
 
-const IssuesPage = () => {
+const LandingPage = () => {
+  const [viewportWidth, setViewportWidth] = useState(0);
+  const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [isMobileViewport, setMobileViewport] = useState(false);
+
+  useEffect(() => {
+    const handleViewportUpdate = () => {
+      const newViewport = window.innerWidth;
+      setViewportWidth(newViewport);
+      viewportWidth < 1024 ? setMobileViewport(true) : setMobileViewport(false);
+    };
+    // Set initial viewport width
+    handleViewportUpdate();
+    window.addEventListener("resize", handleViewportUpdate);
+    // Cleanup eventlistener on unmount
+    return () => window.removeEventListener("resize", handleViewportUpdate);
+  });
   return (
     <div>
       <header className={styles.header}>
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src="/icons/logo-large.svg" alt="Prolog logo" />
-        <a href={Routes.projects}>Dashboard</a>
+        <div className={styles.container}>
+          <div className={styles.logoContainer}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src="/icons/logo-large.svg" alt="Prolog logo" />
+          </div>
+          <div
+            className={classNames(
+              styles.navContainer,
+              isMobileMenuOpen && styles.show,
+            )}
+          >
+            <Link className={styles.navLink} href={Routes.home}>
+              Home
+            </Link>
+            <Link className={styles.navLink} href={Routes.products}>
+              Products
+            </Link>
+            <Link className={styles.navLink} href={Routes.documentation}>
+              Documentation
+            </Link>
+            <Link className={styles.navLink} href={Routes.pricing}>
+              Pricing
+            </Link>
+          </div>
+          <div className={styles.buttonContainer}>
+            <>
+              <Button
+                size="lg"
+                color="primary"
+                className={classNames(
+                  styles.dashboardButton,
+                  isMobileViewport && styles.remove,
+                )}
+                onClick={() => (location.href = Routes.projects)}
+              >
+                Open Dashboard
+              </Button>
+              <Button
+                className={classNames(
+                  styles.dashboardButton,
+                  !isMobileViewport && styles.remove,
+                )}
+                onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={
+                    isMobileMenuOpen
+                      ? "/icons/landing-close.svg"
+                      : "/icons/landing-menu.svg"
+                  }
+                  alt={isMobileMenuOpen ? "close menu" : "open menu"}
+                  className={styles.menuIcon}
+                />
+              </Button>
+            </>
+          </div>
+        </div>
       </header>
       <button
         className={styles.contactButton}
@@ -24,4 +99,4 @@ const IssuesPage = () => {
   );
 };
 
-export default IssuesPage;
+export default LandingPage;

--- a/pages/index.module.scss
+++ b/pages/index.module.scss
@@ -1,19 +1,127 @@
+@use "@styles/color";
+@use "@styles/font";
+@use "@styles/space";
+@use "@styles/breakpoint";
+
 .header {
   width: 100%;
-  height: 80px;
-  padding: 0 2rem;
-  box-sizing: border-box;
+  height: 4.5rem;
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
+  padding: 0;
+  margin: 0;
   background: white;
+  text-align: center;
+
+  @media (min-width: breakpoint.$desktop) {
+    height: space.$s20;
+  }
+}
+
+.container {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: center;
+
+  @media (min-width: breakpoint.$desktop) {
+    width: calc(1280px - 2 * space.$s8);
+    gap: space.$s10;
+  }
+}
+
+.logoContainer {
+  flex: 1;
+  display: flex;
+  justify-content: start;
+  padding-left: space.$s4;
+
+  @media (min-width: breakpoint.$desktop) {
+    padding: space.$s6 0;
+  }
+}
+
+.navContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: space.$s8;
+  position: fixed;
+  top: 0;
+  left: calc(-50% - space.$s2 - 1px);
+  width: 50%;
+  height: 100%;
+  margin-top: 4.5rem;
+  padding-top: space.$s5;
+  padding-left: space.$s2;
+  background-color: color.$gray-50;
+  border: 1px solid color.$gray-300;
+  border-radius: 0 space.$s8 0 0;
+  transition: left 0.3s ease;
+
+  &.show {
+    left: 0;
+    visibility: visible;
+  }
+
+  &.hide {
+    visibility: hidden;
+  }
+
+  @media (min-width: breakpoint.$desktop) {
+    flex: 1;
+    flex-direction: row;
+    position: relative;
+    padding: 0;
+    margin: 0;
+    top: 0;
+    left: 0;
+    align-items: center;
+    background-color: white;
+    gap: space.$s8;
+    list-style: none;
+    border: none;
+    transition: none;
+  }
+}
+
+.navLink {
+  text-decoration: none;
+  font: font.$text-md-semibold;
+  color: color.$gray-500;
+
+  @media (min-width: breakpoint.$desktop) {
+    font: font.$text-md-medium;
+  }
+}
+
+.buttonContainer {
+  padding-right: space.$s3;
+
+  @media (min-width: breakpoint.$desktop) {
+    flex: 1;
+    display: flex;
+    justify-content: end;
+    padding: 0;
+    margin: 0;
+  }
+}
+
+.dashboardButton {
+  padding: 1.375rem 0;
+}
+
+.menuIcon {
+  padding: space.$s2;
 }
 
 .contactButton {
   position: absolute;
-  bottom: 2.5rem;
-  right: 2.5rem;
-  padding: 1rem;
+  bottom: space.$s10;
+  right: space.$s10;
+  padding: space.$s4;
   background: #7f56d9;
   border-radius: 50%;
   box-shadow: 0 1px 2px rgb(16 24 40 / 5%);
@@ -23,4 +131,12 @@
   &:hover {
     background: #6941c6;
   }
+}
+
+.remove {
+  display: none;
+}
+
+.hidden {
+  visibility: hidden;
 }

--- a/public/icons/landing-close.svg
+++ b/public/icons/landing-close.svg
@@ -1,0 +1,3 @@
+<svg width="40" height="40" viewBox="0 0 25 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M26 14L14 26M14 14L26 26" stroke="#344054" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icons/landing-menu.svg
+++ b/public/icons/landing-menu.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3 12H21M3 6H21M3 18H21" stroke="#344054" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
1.) Refactored landing page header to match Figma design specifications.
2.) Implemented animated hamburger menu open/close styling when viewing on a mobile device.
3.) Added landing page routes to our config file.
4.) Added 2 SVG color variants for item 2 above.


Desktop:

![landing-header-desktop](https://github.com/profydev/prolog-app-Hudson-TD/assets/107374040/46a8c383-0b8a-4b1b-ab7e-6f59f9a0a460)


Mobile:

![landing-header-mobile](https://github.com/profydev/prolog-app-Hudson-TD/assets/107374040/89466ccc-d4dc-4596-8b08-b6e8f744300b)
