### PR TITLE
Landing page contact modal

### DIFF
--- a/features/landing/components/contact-modal/contact-modal.module.scss
+++ b/features/landing/components/contact-modal/contact-modal.module.scss
@@ -1,0 +1,20 @@
+@use "@styles/color";
+@use "@styles/font";
+@use "@styles/space";
+@use "@styles/breakpoint";
+
+.contactButton {
+  position: absolute;
+  bottom: space.$s10;
+  right: space.$s10;
+  padding: space.$s4;
+  background: #7f56d9;
+  border-radius: 50%;
+  box-shadow: 0 1px 2px rgb(16 24 40 / 5%);
+  border: none;
+  cursor: pointer;
+
+  &:hover {
+    background: #6941c6;
+  }
+}

--- a/features/landing/components/contact-modal/contact-modal.module.scss
+++ b/features/landing/components/contact-modal/contact-modal.module.scss
@@ -18,3 +18,77 @@
     background: #6941c6;
   }
 }
+
+.modalContainer {
+  width: calc(100% - 2 * space.$s4);
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: space.$s3;
+  background-color: #fff;
+  z-index: 2;
+
+  @media (min-width: breakpoint.$desktop) {
+    width: 400px;
+  }
+}
+
+.modalContent {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: space.$s6;
+  gap: space.$s8;
+}
+
+.contactIcon {
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  padding-bottom: space.$s5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modalTitle {
+  font: font.$text-lg-medium;
+  color: color.$gray-900;
+  text-align: center;
+  padding: 0;
+  margin: 0;
+}
+
+.modalSubtitle {
+  font: font.$text-sm-regular;
+  color: color.$gray-500;
+  text-align: center;
+  padding: 0;
+  margin: 0;
+}
+
+.buttonContainer {
+  width: 100%;
+  display: flex;
+  gap: space.$s3;
+}
+
+.button {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
+// Page blur on modal open
+
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgb(0 0 0 / 30%);
+  backdrop-filter: blur(5px);
+}

--- a/features/landing/components/contact-modal/contact-modal.tsx
+++ b/features/landing/components/contact-modal/contact-modal.tsx
@@ -1,0 +1,17 @@
+import styles from "./contact-modal.module.scss";
+
+export function ContactModal() {
+  return (
+    <button
+      className={styles.contactButton}
+      onClick={() =>
+        alert(
+          "Implement this in Challenge 2 - Modal:\n\nhttps://profy.dev/rjs-challenge-modal",
+        )
+      }
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src="/icons/message.svg" alt="Contact" />
+    </button>
+  );
+}

--- a/features/landing/components/contact-modal/contact-modal.tsx
+++ b/features/landing/components/contact-modal/contact-modal.tsx
@@ -1,17 +1,60 @@
+import { useState } from "react";
+import { Button, ButtonColor, ButtonSize } from "@features/ui";
 import styles from "./contact-modal.module.scss";
 
 export function ContactModal() {
-  return (
-    <button
-      className={styles.contactButton}
-      onClick={() =>
-        alert(
-          "Implement this in Challenge 2 - Modal:\n\nhttps://profy.dev/rjs-challenge-modal",
-        )
-      }
-    >
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img src="/icons/message.svg" alt="Contact" />
-    </button>
+  const [isOpen, setIsOpen] = useState(false);
+
+  function onModalOpen() {
+    console.log("Clicked");
+    setIsOpen(true);
+  }
+
+  return isOpen ? (
+    <div id="overlay" className={styles.overlay}>
+      <div className={styles.modalContainer}>
+        <div className={styles.modalContent}>
+          <div className={styles.textContent}>
+            <div className={styles.contactIcon}>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src="./icons/contact-modal-mail.svg" alt="Envelope Icon" />
+            </div>
+            <p className={styles.modalTitle}>Contact Us Via Email</p>
+            <p className={styles.modalSubtitle}>
+              Any questions? Send us an email at prolog@profy.dev. We usually
+              answer within 24 hours.
+            </p>
+          </div>
+          <div className={styles.buttonContainer}>
+            <Button
+              className={styles.button}
+              size={ButtonSize.lg}
+              color={ButtonColor.gray}
+              onClick={() => setIsOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              className={styles.button}
+              size={ButtonSize.lg}
+              color={ButtonColor.primary}
+              onClick={() =>
+                (location.href =
+                  "mailto:support@prolog-app.com?subject=Support%20Request:&body=")
+              }
+            >
+              Open Email App
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  ) : (
+    <>
+      <button className={styles.contactButton} onClick={() => onModalOpen()}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src="/icons/message.svg" alt="Contact" />
+      </button>
+    </>
   );
 }

--- a/features/landing/components/contact-modal/index.ts
+++ b/features/landing/components/contact-modal/index.ts
@@ -1,0 +1,1 @@
+export { ContactModal } from "./contact-modal";

--- a/features/landing/index.ts
+++ b/features/landing/index.ts
@@ -1,0 +1,1 @@
+export * from "./components/contact-modal";

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { Routes } from "@config/routes";
 import { Button } from "../features/ui/button/button";
+import { ContactModal } from "@features/landing";
 import axios from "axios";
 import Link from "next/link";
 import styles from "./index.module.scss";
@@ -125,17 +126,7 @@ const LandingPage = () => {
           </div>
         </section>
       </main>
-      <button
-        className={styles.contactButton}
-        onClick={() =>
-          alert(
-            "Implement this in Challenge 2 - Modal:\n\nhttps://profy.dev/rjs-challenge-modal",
-          )
-        }
-      >
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src="/icons/message.svg" alt="Contact" />
-      </button>
+      <ContactModal />
     </div>
   );
 };

--- a/pages/index.module.scss
+++ b/pages/index.module.scss
@@ -118,22 +118,6 @@
   padding: space.$s2;
 }
 
-.contactButton {
-  position: absolute;
-  bottom: space.$s10;
-  right: space.$s10;
-  padding: space.$s4;
-  background: #7f56d9;
-  border-radius: 50%;
-  box-shadow: 0 1px 2px rgb(16 24 40 / 5%);
-  border: none;
-  cursor: pointer;
-
-  &:hover {
-    background: #6941c6;
-  }
-}
-
 .remove {
   display: none;
 }

--- a/public/icons/contact-modal-mail.svg
+++ b/public/icons/contact-modal-mail.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" fill="none">
+  <path d="M44 12C44 9.8 42.2 8 40 8H8C5.8 8 4 9.8 4 12M44 12V36C44 38.2 42.2 40 40 40H8C5.8 40 4 38.2 4 36V12M44 12L24 26L4 12" stroke="#101828" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
1.) Implemented contact-modal component for the landing page based on Figma design specifications.
2.) Added screen blur on open of the contact modal to accentuate focus.
3.) Added onClick event to open pre-filled support email in user's default email application.


Desktop:

![contact-modal-desktop](https://github.com/profydev/prolog-app-Hudson-TD/assets/107374040/40149267-dba2-490c-b13c-71cbe617bb90)


Mobile:

![contact-modal-mobile](https://github.com/profydev/prolog-app-Hudson-TD/assets/107374040/76ac6aac-f1bf-4325-ae8f-e71b595b41bd)
